### PR TITLE
PHP Parse error

### DIFF
--- a/src/Pagi.php
+++ b/src/Pagi.php
@@ -87,7 +87,7 @@ class Pagi
             $this->items,
             $this->items->count(),
             $this->perPage,
-            $this->currentPage,
+            $this->currentPage
         );
     }
 }


### PR DESCRIPTION
With this comma removed, I no longer get this error.

```
PHP Parse error:  syntax error, unexpected ')' in sitename/web/app/themes/sage/vendor/log1x/pagi/src/Pagi.php on line 91
```

php -v dump:

```
PHP 7.2.24 (cli) (built: Oct 25 2019 11:13:56) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
    with Zend OPcache v7.2.24, Copyright (c) 1999-2018, by Zend Technologies
```