### PR TITLE
fix(a11y): remove redundant navigation role

### DIFF
--- a/src/resources/views/pagination.blade.php
+++ b/src/resources/views/pagination.blade.php
@@ -1,5 +1,5 @@
 @if ($pagi->hasPages())
-  <nav class="flex items-center my-8" role="navigation" aria-label="pagination">
+  <nav class="flex items-center my-8" aria-label="pagination">
     @if (! $pagi->onFirstPage())
       <a
         href="{{ $pagi->previousPageUrl() }}"


### PR DESCRIPTION
I just noticed that this `role=navigation` is redundant since `navigation` is the implicit role of `<nav>`. IE 9-11 supports the `<nav>` element too.
