### PR TITLE
fix(a11y): set aria-hidden on prev/next link text

### DIFF
--- a/src/resources/views/pagination.blade.php
+++ b/src/resources/views/pagination.blade.php
@@ -6,7 +6,9 @@
         rel="prev"
         aria-label="Previous Page"
         class="border rounded-sm mr-3 py-1 px-4 hover:bg-blue-600 hover:text-white"
-      >&larr; Previous</a>
+      >
+        <span aria-hidden="true">&larr; Previous</span>
+      </a>
     @endif
 
     <ul class="flex">
@@ -43,7 +45,9 @@
         rel="next"
         aria-label="Next Page"
         class="border rounded-sm mr-3 py-1 px-4 hover:bg-blue-600 hover:text-white"
-      >Next &rarr;</a>
+      >
+        <span aria-hidden="true">Next &rarr;</span>
+      </a>
     @endif
   </nav>
 @endif


### PR DESCRIPTION
Since these have a label we need to hide the text content which is used as the label. Right now these announce both the `aria-label` and the text content.
