### PR TITLE
fix(a11y): remove aria-disabled from list item

### DIFF
--- a/src/resources/views/pagination.blade.php
+++ b/src/resources/views/pagination.blade.php
@@ -12,7 +12,7 @@
     <ul class="flex">
       @foreach ($pagi->elements() as $element)
         @if (is_string($element))
-          <li class="disabled" aria-disabled="true">
+          <li class="disabled">
             <span class="mr-3 py-1">&hellip;</span>
           </li>
         @endif


### PR DESCRIPTION
There’s no need to add this since the list item itself isn’t "operable." I think it’s fine to just remove this attribute. Users of screen readers will understand that it’s not a link and that it’s communicating a gap between the pages.
