### PR TITLE
Allow pagination for custom WP_Query

### DIFF
--- a/src/Pagi.php
+++ b/src/Pagi.php
@@ -53,7 +53,7 @@ class Pagi
     {
         $isGlobalQuery = false;
 
-        if (!isset($this->query)) {
+        if (! isset($this->query)) {
             $this->query = collect(
                 Arr::get($GLOBALS, 'wp_query')->query_vars ?? []
             )->filter();
@@ -109,6 +109,12 @@ class Pagi
         );
     }
 
+    /**
+     * Set the WordPress query.
+     *
+     * @param  WP_Query
+     * @return void
+     */
     public function setQuery($query)
     {
         $this->query = collect(

--- a/src/Pagi.php
+++ b/src/Pagi.php
@@ -51,22 +51,30 @@ class Pagi
      */
     protected function prepare()
     {
-        $this->query = collect(
-            Arr::get($GLOBALS, 'wp_query')->query_vars ?? []
-        )->filter();
+        $isGlobalQuery = false;
+
+        if (!isset($this->query)) {
+            $this->query = collect(
+                Arr::get($GLOBALS, 'wp_query')->query_vars ?? []
+            )->filter();
+
+            $isGlobalQuery = true;
+        }
 
         if ($this->query->isEmpty()) {
             return;
         }
 
-        $this->query->put('post_type', get_post_type());
+        if ($isGlobalQuery) {
+            $this->query->put('post_type', get_post_type());
 
-        if (is_tax()) {
-            $this->query->put('tax_query', [[
-                'taxonomy' => $this->query->get('taxonomy'),
-                'terms' => $this->query->get('term'),
-                'field' => 'name',
-            ]]);
+            if (is_tax()) {
+                $this->query->put('tax_query', [[
+                    'taxonomy' => $this->query->get('taxonomy'),
+                    'terms' => $this->query->get('term'),
+                    'field' => 'name',
+                ]]);
+            }
         }
 
         $this->perPage = $this->query->get('posts_per_page');
@@ -99,5 +107,12 @@ class Pagi
             $this->perPage,
             $this->currentPage
         );
+    }
+
+    public function setQuery($query)
+    {
+        $this->query = collect(
+            $query->query_vars ?? []
+        )->filter();
     }
 }


### PR DESCRIPTION
There are cases where one needs to generate the pagination for a custom WP_Query. Here is an example:

```
 $postQuery = new WP_Query([
            'post_type' => 'some_custom_post_type',
            // more conditions
        ]);

$pagination = new Pagi();
$pagination->setQuery($postQuery);
$pagination->build();
```
