### PR TITLE
Added condition to not run query->put('post_type') on search page

### DIFF
--- a/src/Pagi.php
+++ b/src/Pagi.php
@@ -66,7 +66,9 @@ class Pagi
         }
 
         if ($isGlobalQuery) {
-            $this->query->put('post_type', get_post_type());
+            if(! is_search()) {
+                $this->query->put('post_type', get_post_type());
+            }
 
             if (is_tax()) {
                 $this->query->put('tax_query', [[

--- a/src/Pagi.php
+++ b/src/Pagi.php
@@ -66,7 +66,7 @@ class Pagi
         }
 
         if ($isGlobalQuery) {
-            if(! is_search()) {
+            if (! is_search()) {
                 $this->query->put('post_type', get_post_type());
             }
 


### PR DESCRIPTION
When using pagination inside the search page, it didn't work correctly as the "post_type" was set as some CPT.

I'm not sure what the function of this line is, but I think it is not needed in this case.