### PR TITLE
Fix some issues with global queries

### DIFF
--- a/src/LengthAwarePaginator.php
+++ b/src/LengthAwarePaginator.php
@@ -55,15 +55,15 @@ class LengthAwarePaginator extends Paginator
     public function nextPageUrl()
     {
         global $paged;
-        $max_page = count($this->items);
 
-        if ( ! is_single() ) {
-            if ( ! $paged ) {
-                $paged = 1;
-            }
-            $nextpage = (int) $paged + 1;
-            if ( ! $max_page || $max_page >= $nextpage ) {
-                return get_pagenum_link( $nextpage, false );
+        $maxPage = count($this->items);
+
+        if (! is_single()) {
+            $paged = empty($paged) ? 1 : $paged;
+            $nextPage = (int) $paged + 1;
+
+            if (! $maxPage || $maxPage >= $nextPage) {
+                return get_pagenum_link($nextPage, false);
             }
         }
     }
@@ -77,12 +77,11 @@ class LengthAwarePaginator extends Paginator
     {
         global $paged;
 
-        if ( ! is_single() ) {
-            $nextpage = (int) $paged - 1;
-            if ( $nextpage < 1 ) {
-                $nextpage = 1;
-            }
-            return get_pagenum_link( $nextpage, false );
+        if (! is_single()) {
+            $nextPage = (int) $paged - 1;
+            $nextPage = $nextPage < 1 ? 1 : $nextPage;
+
+            return get_pagenum_link($nextPage, false);
         }
     }
 

--- a/src/LengthAwarePaginator.php
+++ b/src/LengthAwarePaginator.php
@@ -56,15 +56,17 @@ class LengthAwarePaginator extends Paginator
     {
         global $paged;
 
-        $maxPage = count($this->items);
+        if (is_single()) {
+            return;
+        }
 
-        if (! is_single()) {
-            $paged = empty($paged) ? 1 : $paged;
-            $nextPage = (int) $paged + 1;
+        $paged = empty($paged) ? 1 : $paged;
 
-            if (! $maxPage || $maxPage >= $nextPage) {
-                return get_pagenum_link($nextPage, false);
-            }
+        $nextPage = (int) $paged + 1;
+        $maxPages = count($this->items);
+
+        if (! $maxPages || $maxPages >= $nextPage) {
+            return get_pagenum_link($nextPage, false);
         }
     }
 
@@ -77,12 +79,14 @@ class LengthAwarePaginator extends Paginator
     {
         global $paged;
 
-        if (! is_single()) {
-            $nextPage = (int) $paged - 1;
-            $nextPage = $nextPage < 1 ? 1 : $nextPage;
-
-            return get_pagenum_link($nextPage, false);
+        if (is_single()) {
+            return;
         }
+
+        $nextPage = (int) $paged - 1;
+        $nextPage = $nextPage < 1 ? 1 : $nextPage;
+
+        return get_pagenum_link($nextPage, false);
     }
 
     /**

--- a/src/LengthAwarePaginator.php
+++ b/src/LengthAwarePaginator.php
@@ -35,7 +35,7 @@ class LengthAwarePaginator extends Paginator
             $page = 1;
         }
 
-        $url = get_pagenum_link($page);
+        $url = get_pagenum_link($page, false);
 
         if (count($this->query) > 0) {
             return $url .
@@ -54,10 +54,18 @@ class LengthAwarePaginator extends Paginator
      */
     public function nextPageUrl()
     {
-        return next_posts(
-            count($this->items),
-            false
-        );
+        global $paged;
+        $max_page = count($this->items);
+
+        if ( ! is_single() ) {
+            if ( ! $paged ) {
+                $paged = 1;
+            }
+            $nextpage = (int) $paged + 1;
+            if ( ! $max_page || $max_page >= $nextpage ) {
+                return get_pagenum_link( $nextpage, false );
+            }
+        }
     }
 
     /**
@@ -67,7 +75,15 @@ class LengthAwarePaginator extends Paginator
      */
     public function previousPageUrl()
     {
-        return previous_posts(false);
+        global $paged;
+
+        if ( ! is_single() ) {
+            $nextpage = (int) $paged - 1;
+            if ( $nextpage < 1 ) {
+                $nextpage = 1;
+            }
+            return get_pagenum_link( $nextpage, false );
+        }
     }
 
     /**

--- a/src/Pagi.php
+++ b/src/Pagi.php
@@ -46,7 +46,7 @@ class Pagi
                 Arr::get($GLOBALS, 'wp_query')->query_vars ?? []
             )->filter();
 
-            $this->items = collect()->range(0, $GLOBALS['wp_query']->found_posts);
+            $this->items = collect()->range(0, Arr::get($GLOBALS, 'wp_query')->found_posts);
         }
 
         if ($this->query->isEmpty()) {

--- a/src/Pagi.php
+++ b/src/Pagi.php
@@ -77,7 +77,7 @@ class Pagi
     /**
      * Set the WordPress query.
      *
-     * @param  WP_Query
+     * @param  \WP_Query
      * @return void
      */
     public function setQuery($query)

--- a/src/Pagi.php
+++ b/src/Pagi.php
@@ -41,16 +41,12 @@ class Pagi
      */
     protected function prepare()
     {
-        $isGlobalQuery = false;
-
         if (! isset($this->query)) {
             $this->query = collect(
                 Arr::get($GLOBALS, 'wp_query')->query_vars ?? []
             )->filter();
 
             $this->items = collect()->range(0, $GLOBALS['wp_query']->found_posts);
-            
-            $isGlobalQuery = true;
         }
 
         if ($this->query->isEmpty()) {


### PR DESCRIPTION
Hi! 

I was encountering a number of issues, so I thought I would open a pull request, if not to solve those issues right away, at least to pick your brain.

## Multiple terms as query var
The first issue was that I couldn't paginate a post type archive page that uses a taxonomy to filter with multiple terms as query vars. Ex.: http://website.com/projects/?project-category[]=slug1&project-category[]=slug2. I ended up plainly removing the ```post_type``` addition and ```is_tax``` check at [Pagi.php:71](https://github.com/Log1x/pagi/blob/master/src/Pagi.php#L71) and all that was in that block, since it was recreating wrongly the current global query. An argument could be made that ```is_tax``` shouldn't be true on that page since it's a custom post type archive, but the fact is that WordPress does differently: when terms are in query vars, it activates ```is_tax => true``` on ```WP_Query```, hence the error. But, in the end, the ```is_tax``` block shouldn't even be needed because of [all the query vars that we pluck a few lines up and should already be defined](https://github.com/Log1x/pagi/blob/master/src/Pagi.php#L57).

## URLs with query strings getting re-encoded
Around [LengthAwarePaginator.php:32](https://github.com/Log1x/pagi/blob/master/src/LengthAwarePaginator.php#L32), the functions that generate the current page, previous page and next page's URL are escaping by default and if there's a query string with multiple params, html characters get re-encoded. The only function down the line that allows us to not escape to avoid a double-escape situation is the ```get_pagenum_link``` function that I used to recreate ```get_next_posts_page_link``` and ```get_previous_posts_page_link```.

## Unecessary round trip to the database
I was wondering if there was an explanation for the (get_posts)[https://github.com/Log1x/pagi/blob/master/src/Pagi.php#L84] which makes an extra round trip to the database. In any case, I figured it was simply to create an ```Illuminate\Support\Collection``` to pass to ```LengthAwarePaginator``` and let the Laravel Paginators do their magic, but if there's no use to have the posts data in there, the better solution to optimize this was to simply create an empty collection with the ```range``` function and using the ```$query->found_posts``` to fill it up to the right amount which, in turns, allows the creation of the pagination correctly.