### PR TITLE
Fix: range function offset

### DIFF
--- a/src/Pagi.php
+++ b/src/Pagi.php
@@ -46,7 +46,7 @@ class Pagi
                 Arr::get($GLOBALS, 'wp_query')->query_vars ?? []
             )->filter();
 
-            $this->items = collect()->range(0, Arr::get($GLOBALS, 'wp_query')->found_posts);
+            $this->items = collect()->range(1, Arr::get($GLOBALS, 'wp_query')->found_posts);
         }
 
         if ($this->query->isEmpty()) {


### PR DESCRIPTION
Sorry about this one. Simple mistake: the range collection function creates an array from x number to y number inclusively (and not "fill by this amount" as I initially thought). It created a +1 offset bug with an impossible page to reach at the end of the pagination, so that pull request should fix it.