### PR TITLE
Fix: range function offset in setQuery

### DIFF
--- a/src/Pagi.php
+++ b/src/Pagi.php
@@ -82,7 +82,7 @@ class Pagi
      */
     public function setQuery($query)
     {
-        $this->items = collect()->range(0, $query->found_posts);
+        $this->items = collect()->range(1, $query->found_posts);
         $this->query = collect(
             $query->query_vars ?? []
         )->filter();


### PR DESCRIPTION
Like for the #14 in the prepare function, we have to range from 1 (and not 0) to found_posts to avoid an impossible page to reach at the end of the pagination.