### PR TITLE
Fix division by zero

### DIFF
--- a/src/Pagi.php
+++ b/src/Pagi.php
@@ -53,7 +53,7 @@ class Pagi
             return;
         }
 
-        $this->perPage = $this->query->get('posts_per_page');
+        $this->perPage = $this->query->get('posts_per_page', 1);
         $this->currentPage = max(1, absint(get_query_var('paged')));
     }
 


### PR DESCRIPTION
In some rare cases there can be query params, however this doesn't mean there is specifically a `posts_per_page` var. If this happens, `perPage` defaults to `null` which causes a division by zero error in the LengthAwarePaginator of Illuminate.